### PR TITLE
Adjusting regex rules to support longer jira-key issues

### DIFF
--- a/chrome-extension/js/jira-parser.js
+++ b/chrome-extension/js/jira-parser.js
@@ -1,7 +1,7 @@
 var JiraParser = (function () {
     const hoursAndMinutesRegex = /^(\d+[m]|\d+[h](?:\s\d+[m])?)$/,
-        jiraNumberRegex = /^([a-zA-Z]{1,10}-\d+)$/,
-        worklogTextLineRegex = /\b([a-zA-Z]{1,10}-\d+)?\b.*?\b(\d+[m]|\d+[h](?:\s\d+[m])?)\b[\s\-_;,]*(.+)$/;
+        jiraNumberRegex = /^([a-zA-Z]{1,30}-\d+)$/,
+        worklogTextLineRegex = /\b([a-zA-Z]{1,30}-\d+)?\b.*?\b(\d+[m]|\d+[h](?:\s\d+[m])?)\b[\s\-_;,]*(.+)$/;
 
     function timeSpentToHours(timeSpent) {
         var result = 0;


### PR DESCRIPTION
A tweak to support longer jira-key issues.

_Did some local testing and it is still working to insert, edit and update worklogs using jira-key (up to 30 characters long)_

