### PR TITLE
Update parser to support Jirakey with number

### DIFF
--- a/chrome-extension/js/jira-parser.js
+++ b/chrome-extension/js/jira-parser.js
@@ -1,7 +1,7 @@
 var JiraParser = (function () {
     const hoursAndMinutesRegex = /^(\d+[m]|\d+[h](?:\s\d+[m])?)$/,
-        jiraNumberRegex = /^([a-zA-Z]{1,30}-\d+)$/,
-        worklogTextLineRegex = /\b([a-zA-Z]{1,30}-\d+)?\b.*?\b(\d+[m]|\d+[h](?:\s\d+[m])?)\b[\s\-_;,]*(.+)$/;
+        jiraNumberRegex = /^([a-zA-Z0-9]{1,30}-\d+)$/,
+        worklogTextLineRegex = /\b([a-zA-Z0-9]{1,30}-\d+)?\b.*?\b(\d+[m]|\d+[h](?:\s\d+[m])?)\b[\s\-_;,]*(.+)$/;
 
     function timeSpentToHours(timeSpent) {
         var result = 0;

--- a/tests/unit/jira-helper.unit.spec.js
+++ b/tests/unit/jira-helper.unit.spec.js
@@ -288,6 +288,18 @@ describe('Jira API Helper', () => {
             
             done();
         })
+        test('returns jira url successfully when jira # is long CMSSSS-321654987', done => {
+            const jiraUrl = jiraHelper.getJiraUrl("CMSSSS-321654987");
+            expect(jiraUrl).toEqual("https://whatever.com/browse/CMSSSS-321654987");
+            
+            done();
+        })        
+        test('returns jira url successfully when jiraname has # CMS2020-123', done => {
+            const jiraUrl = jiraHelper.getJiraUrl("CMS2020-123");
+            expect(jiraUrl).toEqual("https://whatever.com/browse/CMS2020-123");
+            
+            done();
+        })        
         test('fails to return jira URL when jira # is empty', done => {
             const jiraUrl = jiraHelper.getJiraUrl("");
             expect(jiraUrl).toEqual("");

--- a/tests/unit/jira-parser.unit.spec.js
+++ b/tests/unit/jira-parser.unit.spec.js
@@ -286,5 +286,17 @@ describe('validate fields', () => {
             let result = jiraParser.getInvalidFields(item);
             expect(result).toMatchObject(invalidFields);
         })
+        
+        test('Testing Jirakey Name with Number', () => {
+            let item = {
+                jira: "JIRA2020-123",
+                timeSpent: "1h 45m",
+                comment: "test"
+            },
+            invalidFields = []
+            
+            let result = jiraParser.getInvalidFields(item);
+            expect(result).toMatchObject(invalidFields);
+        })
     })
 })


### PR DESCRIPTION
# Changes
Updated the `chrome-extension/js/jira-parser.js` to support Jira-Key names with numbers (e.g. _CMS**2019**-123_).

## Affected files
Created some extra unit tests to validate those new possibilities. Those changes were made on files `tests/unit/jira-helper.unit.spec.js` and `tests/unit/jira-parser.unit.spec.js`.

## Known issues
Tried running the 'Integration' automated tests but they failed (:small_red_triangle_down:). Tried at master branch and they also failed. I believe that it is a problem related to development environment setup, puppeteer plugin or a mix of both. All the other tests passed (:white_check_mark:).

### $ yarn test // summary of tests
![image](https://user-images.githubusercontent.com/1964524/58439683-bff86200-80ab-11e9-908b-ec30ac19e358.png)
